### PR TITLE
feat: add watch option + emit BuilderOutput

### DIFF
--- a/src/builders/build/index.ts
+++ b/src/builders/build/index.ts
@@ -27,9 +27,7 @@ export const execute = (options: any, context: BuilderContext): Observable<Build
   return from(setup()).pipe(
     map(project => normalizeOptions(options, project, context)),
     map(options => buildConfig(options)),
-    switchMap(webpackConfig => runWebpack(webpackConfig, context)),
-    mapTo({ success: true }
-    )
+    switchMap(webpackConfig => runWebpack(webpackConfig, context))
   )
 }
 
@@ -69,7 +67,7 @@ function buildConfig(options) {
     entry,
     mode: 'production',
     target: 'node',
-    watch: true,
+    watch: options.watch,
     output: {
       path: options.outputPath,
       filename: '[name].js'

--- a/src/builders/build/schema.json
+++ b/src/builders/build/schema.json
@@ -32,6 +32,11 @@
     },
     "tsConfig": {
       "type": "string"
+    },
+    "watch": {
+      "description": "Whether to run webpack in watch mode or not.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["main", "outputPath", "tsConfig"],


### PR DESCRIPTION
Note: ngtron already passes watch option to ngnode. So, no breaking change in that direction.